### PR TITLE
feat:integrate create warehouse

### DIFF
--- a/src/api/warehouse/createWarehouse.ts
+++ b/src/api/warehouse/createWarehouse.ts
@@ -1,0 +1,20 @@
+import axios from 'axios';
+
+import { AddWarehouse } from '@/types/warehouse';
+
+type TParams = {
+    name: string;
+    location: string;
+    size: number;
+    storageCapacity: number;
+};
+
+type TCreateWarehouseResponse = {
+    message: string;
+    data: AddWarehouse;
+    token: string;
+}
+
+export const createWarehouse = async (params: TParams) => {
+    return axios.post<TCreateWarehouseResponse>(`/warehouse`, params);
+};

--- a/src/features/AssetManagement/Warehouse/WarehouseForm.tsx
+++ b/src/features/AssetManagement/Warehouse/WarehouseForm.tsx
@@ -10,6 +10,9 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { X } from 'lucide-react';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
+import { createWarehouse } from '@/api/warehouse/createWarehouse';
+import { useToast } from '@/components/Toaster';
+import { useMutation } from '@tanstack/react-query';
 
 export type WarehouseFormProps = {
   values?: TWarehouseFormSchema;
@@ -33,9 +36,32 @@ export function WarehouseForm({ values = defaultValues, variant, button, onSubmi
     defaultValues: values,
   });
 
+  const { toast } = useToast();
+  const createWarehouseMutation = useMutation({
+    mutationFn: createWarehouse,
+  });
+
   const handleSubmit = async (data: TWarehouseFormSchema) => {
     setIsFormOpen(false);
-    await onSubmit(data);
+    if (variant === 'create') {
+      try {
+        await createWarehouseMutation.mutateAsync({
+          name: data.warehouseName,
+          location: data.warehouseLocation,
+          size: data.warehouseSize,
+          storageCapacity: data.warehouseCapacity,
+        });
+        toast({
+          description: 'Warehouse successfully created!',
+          className: 'bg-green-700/70 text-white border border-green-500 rounded-none text-center',
+          duration: 3000,
+        });
+      } catch (error) {
+        console.error('Failed to create warehouse:', error);
+      }
+    } else {
+      await onSubmit(data);
+    }
   };
 
   useEffect(() => {

--- a/src/types/warehouse.ts
+++ b/src/types/warehouse.ts
@@ -1,0 +1,26 @@
+export type AddWarehouse = {
+    message: string;
+    data: {
+        id: string;
+        name: string;
+        location: string;
+        size: number;
+        storageCapacity: number;
+    };
+    createdAt: {
+        dateTime: string;
+        time: string;
+        date: string;
+        dateFull: string;
+        raw: string;
+      };
+      updatedAt: {
+        dateTime: string;
+        time: string;
+        date: string;
+        dateFull: string;
+        raw: string;
+      };
+      isDeleted: boolean;
+}
+


### PR DESCRIPTION
### As a user, I want to create a warehouse for my materials/assets where I will be adding my inventory items
### BOARD LINK - https://dev.azure.com/AnteERP/Ante/_boards/board/t/Ante%20Team/Stories/?workitem=160
### EXPECTED RESULT
- On save clicked, call create warehouse API
- On return,
a. Success: 
-- Display success message
-- Close form
-- Refresh list of displayed warehouses
b. Failed: Display failed message

### SUMMARY OF CHANGES
- add new warehouse file for API
- add new types file for warehouse data
- Integrate create  warehouse form
### LOCAL TESTING 

https://github.com/primia3d/ante-frontend/assets/141484065/220835ef-c4b3-4ebc-8cd7-08d8a1d6d170

